### PR TITLE
Created 2019-07-02 transparency report

### DIFF
--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -8,7 +8,7 @@
 Between 2018-11-09 and 2019-07-09, the Code of Conduct committee has not received an incident report, although the [Incident Reporting Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform) was submitted once with no information included.
 
 ### Potential Code of Conduct Breaches  
-There have been no officially reported Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct committee. 
+There have been no officially reported Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a relevant task force.
 
 ## Summary of Police Matters
 There were no police matters

--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -5,10 +5,10 @@
 
 ### Reports
 
-In the last eight months, the Code of Conduct committee has not received an incident report, although the [Incident Reporting Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform) was submitted once with no information included
+In the last eight months, the Code of Conduct committee has not received an incident report, although the [Incident Reporting Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform) was submitted once with no information included.
 
 ### Potential Code of Conduct Breaches  
-There have been no **reported** Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct.
+There have been no **reported** Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct committee. 
 
 ## Summary of Police Matters
 There were no police matters

--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -5,10 +5,10 @@
 
 ### Reports
 
-In the last eight months, the Code of Conduct committee has not received an incident report, although the [Incident Reporting Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform) was submitted once with no information included.
+Between 2018-11-09 and 2019-07-09, the Code of Conduct committee has not received an incident report, although the [Incident Reporting Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform) was submitted once with no information included.
 
 ### Potential Code of Conduct Breaches  
-There have been no **reported** Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct committee. 
+There have been no officially reported Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct committee. 
 
 ## Summary of Police Matters
 There were no police matters

--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -1,0 +1,29 @@
+# The Carpentries Code of Conduct Transparency Report
+## 2019 July 02
+
+## Overview
+
+### Reports
+
+In the last eight months, the Code of Conduct committee has not received an incident report through the [Code of Conduct Incident Report Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform).
+
+### Potential Code of Conduct Breaches  
+There have been no **reported** Code of Conduct breaches in the last eight months. The Executive Council has approved a task force that will develop recommendtions for incidents that fall outside the scope of the Code of Conduct.
+
+## Summary of Police Matters
+There were no police matters
+
+## Summary of Policy Matters
+The Carpentries Code of Conduct Documentation was revised for transparency and clarity 2019 February. Highlights from these revisions include:
+
+- Allowing reports to be filed anonymously.  
+- Explaining if and when Executive Council and Carpentries Staff would be made known of Code of Conduct incidents.  
+- Providing incident response checklists for in-person events.  
+- Specifying the audience for each of the Code of Conduct documents.  
+- Processes to ensure reports will maintain the reporter’s anonymity.  
+
+Links to corresponding blog posts are located below.
+
+- [Code of Conduct Documentation Open for Comments](https://carpentries.org/blog/2019/01/coc-documentation-rfc/) - 2019-01-31
+- [Code of Conduct Documentation Revised for Transparency and Clarity](https://carpentries.org/blog/2019/02/coc-documentation-release/) -  2019-02-28
+

--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -5,7 +5,7 @@
 
 ### Reports
 
-In the last eight months, the Code of Conduct committee has not received an incident report.
+In the last eight months, the Code of Conduct committee has not received an incident report, although the [Incident Reporting Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform) was submitted once with no information included
 
 ### Potential Code of Conduct Breaches  
 There have been no **reported** Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct.

--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -8,7 +8,7 @@
 In the last eight months, the Code of Conduct committee has not received an incident report.
 
 ### Potential Code of Conduct Breaches  
-There have been no **reported** Code of Conduct breaches in the last eight months. The Executive Council has approved a task force that will develop recommendtions for incidents that fall outside the scope of the Code of Conduct.
+There have been no **reported** Code of Conduct breaches in the last eight months. However, discussions in the community and within the Code of Conduct committee have led the Executive Council to approve a task force that will develop recommendations for incidents that fall outside the scope of the Code of Conduct.
 
 ## Summary of Police Matters
 There were no police matters
@@ -17,7 +17,7 @@ There were no police matters
 The Carpentries Code of Conduct Documentation was revised for transparency and clarity 2019 February. Highlights from these revisions include:
 
 - Allowing reports to be filed anonymously.  
-- Explaining if and when Executive Council and Carpentries Staff would be made known of Code of Conduct incidents.  
+- Clarifying if and when Executive Council and Carpentries Staff would be made known of Code of Conduct incidents.  
 - Providing incident response checklists for in-person events.  
 - Specifying the audience for each of the Code of Conduct documents.  
 - Processes to ensure reports will maintain the reporter’s anonymity.  

--- a/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-07-02-coc-transparency-report.md
@@ -5,7 +5,7 @@
 
 ### Reports
 
-In the last eight months, the Code of Conduct committee has not received an incident report through the [Code of Conduct Incident Report Form](https://docs.google.com/forms/d/e/1FAIpQLSdi0wbplgdydl_6rkVtBIVWbb9YNOHQP_XaANDClmVNu0zs-w/viewform).
+In the last eight months, the Code of Conduct committee has not received an incident report.
 
 ### Potential Code of Conduct Breaches  
 There have been no **reported** Code of Conduct breaches in the last eight months. The Executive Council has approved a task force that will develop recommendtions for incidents that fall outside the scope of the Code of Conduct.


### PR DESCRIPTION
Per the [bylaws](https://docs.carpentries.org/topic_folders/policies/enforcement-guidelines.html#accountability): At the end of every quarter, the Executive Council will publish an aggregated count of the incidents the Code of Conduct Committee reviewed, indicating how many reports it received, how many incidents it investigated independently, how many times it acted unilaterally, and, for each of these, under which part of the Code of Conduct the incident was classified. Here is a draft of this report.

@kcranston for your review