### PR TITLE
Added Code of Conduct transparency report for 2019 July - Oct

### DIFF
--- a/code-of-conduct-transparency-reports/2019-10-10-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2019-10-10-coc-transparency-report.md
@@ -1,0 +1,26 @@
+# The Carpentries Code of Conduct Transparency Report
+
+2019 October 10th
+## Overview
+
+### Reports
+Between 2019-07-09 and 2019-10-10, the Code of Conduct committee has not received any formal incident reports. 
+However, the Incident form was filled out once, with information about an incident that was outside of the scope
+of the Carpentries Code of Conduct. 
+
+### Potential Code of Conduct Breaches
+The committee has not investigated any Code of Conduct breaches in the last three months. 
+However, discussions in the community and within the Code of Conduct committee led 
+the Executive Council to approve a relevant task force. This taskforce handed in their 
+recommendations on the 19th of September.
+
+### Summary of Police Matters
+There were no police matters.
+
+### Summary of Policy Matters
+
+* The committee has worked on its governance documents, which will be released to the community late October.
+The main concerns have been committee membership, voting structure and term limits.
+* Two new members were onboarded to the committee - Benjamin Schwessinger and Ivo Arrey. Simon Waldman will be stepping down from the committee at the end of the year.
+* [The Code of Conduct Committee Mandate Task Force Recommendations were finalized on the 19th of September.](https://github.com/carpentries/task-forces/blob/master/2019/incidents-outside-cocc/2019-09-19-cocc-taskforce-summary-recommendations.md) 
+ 


### PR DESCRIPTION
@kcranston The CoC transparency report has been added to the executive council info repo.