### PR TITLE
creating year in review documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Carpentries Executive Council
 
-This repository contains documentation on processes and meetings for the Carpentries Executive Council (EC), and are intended to provide transparency in leadership to the Carpentries community. 
+This repository contains documentation on processes and meetings for the Carpentries Executive Council (EC), and are intended to provide transparency in leadership to the Carpentries community.
 
-[The Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council), 
+[The Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council),
 found in The Carpentries Handbook, describe the composition and main responsibilities of the EC. Current and past members, including which members are officers, can be found in the [Governance section](http://static.carpentries.org/governance/) of the Carpentries website.
 
 If you have a question or concern about EC operations, there are two ways you should feel free to communicate with us:
@@ -13,3 +13,4 @@ Documentation is organized as follows:
 * [process](process): information about onboarding/offboarding new EC members, yearly tasks/timeline, and specific details of how responsibilities for members and officers are implemented
 * [code-of-conduct-transparency-reports](code-of-conduct-transparency-reports): public releases describing incidents reported to the Code of Conduct Committee
 * [minutes](minutes): formally approved minutes from monthly EC meetings
+* [year-in-review](year-in-review): descriptions of main tasks accomplished by each year's Executive Council

--- a/year-in-review/README.md
+++ b/year-in-review/README.md
@@ -1,0 +1,5 @@
+# Executive Council Yearly Summaries
+
+These documents include a list of the Executive Council Members (and officers) for each year, as well as a summary of the major activities accomplished by each Executive Council.
+
+"Elected" references Community-elected members, while "Appointed" refers to Council-elected members. The dates in each document reference only the current term in which the member is serving (some individuals serve multiple terms).

--- a/year-in-review/ec-2018.md
+++ b/year-in-review/ec-2018.md
@@ -1,0 +1,24 @@
+# 2018 Executive Council Year in Review
+
+Members included:
+- Karen Cranston (Appointed for 2018-2019 term, Chair)
+- Kate Hertweck (Appointed for 2018-2019 term, Vice Chair)
+- Lex Nederbragt (Elected for 2018-2019 term, Secretary)
+- Sue McClatchy (Appointed for 2018 term, Treasurer)
+- Amy Hodge (Elected for 2018-2019 term)
+- Mateusz Kuzak (Appointed for 2018 term)
+- Raniere Silva (Elected for 2018-2019 term)
+- Ethan White (Appointed for 2018 term)
+- Elizabeth Wickes (Elected for 2018 term-2019, Code of Conduct committee liaison)
+
+As this was the first Executive Council for The Carpentries following the merger, some terms of Members (listed above) were atypical in duration.
+
+Major accomplishments included:
+- Developed a strategy for internal communications, including onboarding/offboarding procedure followed when new members join the Council and previous members leave
+- Wrote and approved bylaws for The Carpentries following the merger
+- Wrote and approved the Mission statement for The Carpentries
+- Developed and implemented a strategy for the Executive Council to communicate with the community, including newsletter updates and requests for comments on bylaws, mission, and vision
+- Developed a process for Executive Council elections
+- Developed and implemented a policy for determining requirements for new Lesson Programs
+- Reviewed and approved application of Library Carpentry as an official Lesson Program within The Carpentries
+- Approved harmonization of language surrounding self-organized workshop fees (had previously differed between Software Carpentry and Data Carpentry)

--- a/year-in-review/ec-2019.md
+++ b/year-in-review/ec-2019.md
@@ -1,0 +1,20 @@
+# 2019 Executive Council Year in Review
+
+Members included:
+- Amy Hodge [Elected since 2019] Chair
+- Kate Hertweck [Appointed since 2018] Vice Chair
+- Mesfin Diro Chaka [Appointed since 2019] Secretary
+- Raniere Silva [Elected since 2018] Treasurer
+- Elizabeth Wickes [Elected since 2018]
+- Karen Cranston [Appointed since 2018] Code of Conduct committee liaison
+- Joslynn Lee [Appointed since 2019]
+- Lex Nederbragt [Elected since 2018]
+- Juan Steyn [Appointed since 2019]
+
+- Wrote and approved a Vision statement for The Carpentries
+- Approved creation of a task force to provide recommendations for incidents outside the current scope of the Carpentries CoC
+- Approved creation of a task force to work on a sponsorship model
+- Participated in a task force to develop a values statement
+- Streamlined election procedures, including membership drive to update community records in AMY
+- Created a strategic plan for The Carpentries
+- Convened a committee to lead the search for the next Executive Director

--- a/year-in-review/ec-2020.md
+++ b/year-in-review/ec-2020.md
@@ -1,0 +1,12 @@
+# 2019 Executive Council Year in Review
+
+Members included:
+- Amy Hodge [Elected since 2019]
+- Mesfin Diro Chaka [Appointed since 2019]
+- Elizabeth Wickes [Elected since 2018]
+- Joslynn Lee [Appointed since 2019]
+- Juan Steyn [Appointed since 2019]
+- Lex Nederbragt [Elected since 2020]
+- Paula Andrea Martinez [Elected since 2020]
+- Cedric Chambers [Appointed since 2020]
+- Konrad Förstner [Appointed since 2020]


### PR DESCRIPTION
New folder with README, documented in main repo README, added docs for 2019 and 2018, and created placeholder for 2020.

Pinging @amyehodge for a second set of eyes. Please merge if this looks ok!