### PR TITLE
Changed date elected

### DIFF
--- a/year-in-review/ec-2020.md
+++ b/year-in-review/ec-2020.md
@@ -6,7 +6,7 @@ Members included:
 - Elizabeth Wickes [Elected since 2018]
 - Joslynn Lee [Appointed since 2019]
 - Juan Steyn [Appointed since 2019]
-- Lex Nederbragt [Elected since 2020]
+- Lex Nederbragt [Elected since 2018]
 - Paula Andrea Martinez [Elected since 2020]
 - Cedric Chambers [Appointed since 2020]
 - Konrad Förstner [Appointed since 2020]


### PR DESCRIPTION
I feel it would be appropriate to acknowledge member's earlier terms also. Another solution would be to list all election dates, like so:

- Lex Nederbragt [Elected since 2018, re-elected since 2020]
