### PR TITLE
Adding details for the CoC Transparency Reports from 2020

### DIFF
--- a/code-of-conduct-transparency-reports/2020-04-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-04-01-coc-transparency-report.md
@@ -6,7 +6,7 @@
 
 ### Reports
 
-Between 2020-02-01 and 2020-03-31, the Code of Conduct committee processed one formal incident report. 
+Between 2020-02-01 and 2020-03-31, the Code of Conduct committee processed NO formal incident report. 
 
 ### Potential Code of Conduct Breaches
 

--- a/code-of-conduct-transparency-reports/2020-04-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-04-01-coc-transparency-report.md
@@ -26,5 +26,5 @@ There were no committee changes.
 
 ### Further relevant information
 
-- BioHackathon CoC
-- Karen World contacted regarding CoC governance as template/inspirastion for trainer governance
+- The Carpentries CoC was adopted by Virtual BioHackathon Covid-19 2020.
+- The CoC committee shared the governance plan with Karen Word who was developing the governance for the Trainer's Team.

--- a/code-of-conduct-transparency-reports/2020-07-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-07-01-coc-transparency-report.md
@@ -26,4 +26,5 @@ There were no committee changes.
 
 ### Further relevant information
 
-- Changed to GDPR compliant file storage
+- The Carpentries, Staff Liaison, François Michonneau moved the CoC files to a GDPR compliant file storage.
+- A policy update will be made in the document once the legal approval is received by the Staff Liaison.

--- a/code-of-conduct-transparency-reports/2020-07-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-07-01-coc-transparency-report.md
@@ -6,7 +6,7 @@
 
 ### Reports
 
-Between 2020-04-01 and 2020-06-30, the Code of Conduct committee processed one formal incident report. 
+Between 2020-04-01 and 2020-06-30, the Code of Conduct committee processed NO formal incident report. 
 
 ### Potential Code of Conduct Breaches
 

--- a/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
@@ -22,7 +22,10 @@ There were no policy changes.
  
 ### Committee changes
 
-- Karen Lagison stept back as chair; Malvika Sharan and Keren World took co-chair roles
+- Karin Lagesen stepped down after service as a chair of the CoC committee since 2018. 
+She will remain as a member of the committee.
+- As we continue to finalise the CoC governance document, 
+Malvika Sharan was appointed as the Incident Response Chair and Karen Cranston was appointed as the Governance Chair of the committee. 
 
 ### Further relevant information
 

--- a/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
@@ -6,7 +6,7 @@
 
 ### Reports
 
-Between 2020-07-01 and 2020-09-30, the Code of Conduct committee processed one formal incident report. 
+Between 2020-07-01 and 2020-09-30, the Code of Conduct committee processed NO formal incident report. 
 
 ### Potential Code of Conduct Breaches
 

--- a/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
@@ -29,4 +29,4 @@ Malvika Sharan was appointed as the Incident Response Chair and Karen Cranston w
 
 ### Further relevant information
 
-- CoC members (Ivo, Malvika) acted as CarpentryCon facilitators 
+- Two CoC members, Ivo Arrey and Malvika Sharan volunteered to take the role of CoC facilitators during the CarpentryCon @ Home 2020.

--- a/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
@@ -29,4 +29,5 @@ Malvika Sharan was appointed as the Incident Response Chair and Karen Cranston w
 
 ### Further relevant information
 
+- On 23 September 2020, [the CoCc Governance document](https://docs.carpentries.org/topic_folders/policies/coc-governance.html) was added to the handbook. This document is approved by the members of the Code of Conduct committee, the executive director, Kari L. Jordan and executive committee. Contributors: drafted by Karin Lagesen, Malvika Sharan and Karen Word (2019) and extensively reviewed and updated by the committee members of the Code of Conduct committee: Karin Lagesen, Malvika Sharan, Karen Word, Samatha Ahern, Ivo Arrey, Benjamin Schwessinger, François Michonneau and Konrad Förstner (2019-2020).
 - Two CoC members, Ivo Arrey and Malvika Sharan volunteered to take the role of CoC facilitators during the CarpentryCon @ Home 2020.

--- a/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2020-10-01-coc-transparency-report.md
@@ -6,11 +6,17 @@
 
 ### Reports
 
-Between 2020-07-01 and 2020-09-30, the Code of Conduct committee processed NO formal incident report. 
+Between 2020-07-01 and 2020-09-30, the Code of Conduct committee processed one formal incident report. 
 
 ### Potential Code of Conduct Breaches
 
-There was one report of an incident: One unidentified individual joint a Zoom call of a workshop and left without any disruption. This was reported to the workshop administrators.
+There was one report of an incident where a post-workshop survey was flagged to us with the following comment:
+> "Unverified email addresses lead to a known stalker registering as a participant and attending the first half of the workshop."
+
+- The report was acknowledged, however it was pointed out by CoC members that it was not reported if the unknown person who was referred to as a stalker had done anything to breach the CoC or disrupt the classroom. Since, that was not the case, this incident was flagged as a Zoom security-related issue, which should not fall into CoC purview. 
+- The report was transferred to the Workshop Administrators, with the description that Zoom-bombing/stalking can be avoided by setting the registration controlled access to the Zoom room. 
+- To follow up on this from a security perspective, the Quality Assurance Manager informed the reporter that -- our events are all intentionally open as we do not want to create barriers to participation.  For the event mentioned below, we do not know if this event was hosted in a Carpentries Zoom room or by the host institution. If it was the host's own Zoom account, then it is their responsibility to set up security the way they want.  For our events, we recommend that they create a waiting room so the host can decide who to let in.
+- The document explaning Zoom related instructions was further shared to ensure that this incident doesn't repeat: https://docs.carpentries.org/topic_folders/communications/tools/zoom_rooms.html#creating-a-waiting-room.
 
 ### Summary of Police Matters
 

--- a/code-of-conduct-transparency-reports/2021-01-06-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2021-01-06-coc-transparency-report.md
@@ -6,7 +6,7 @@
 
 ### Reports
 
-Between 2020-10-01 and 2020-12-31, the Code of Conduct committee processed one formal incident report. 
+Between 2020-10-01 and 2020-12-31, the Code of Conduct committee processed NO formal incident report. 
 
 ### Potential Code of Conduct Breaches
 

--- a/code-of-conduct-transparency-reports/2021-01-06-coc-transparency-report.md
+++ b/code-of-conduct-transparency-reports/2021-01-06-coc-transparency-report.md
@@ -22,8 +22,8 @@ There were no policy changes.
  
 ### Committee changes
 
-- Samatha Aheran step down from the commitee 
+- Samatha Ahern stepped down after serving as a CoC committee member from 2018-2020.
 
 ### Further relevant information
 
-- CoC facilitors program was announced
+- The [Community facilitors program](https://carpentries.org/blog/2020/09/introducing-community-facilitators-program/) was announced that will teach a module on Code of Conduct facilitation. As per the pist, this module will bridge between community members at events and our Code of Conduct processes.

--- a/code-of-conduct-transparency-reports/README.md
+++ b/code-of-conduct-transparency-reports/README.md
@@ -3,3 +3,42 @@
 This directory includes Code of Conduct Transparency reports. Full information
 on our Code of Conduct, Reporting Guidelines and Enforcement Manual can be
 found in [The Carpentries handbook](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
+
+### Please use the template below for transparency report
+
+```
+# The Carpentries Code of Conduct Transparency Report
+
+yyyy-mm-dd
+
+## Overview
+
+### Reports
+
+Between yyyy-mm-dd and yyyy-mm-dd, the Code of Conduct committee processed <number of reports, 'NO' when none> formal incident report. 
+
+### Potential Code of Conduct Breaches
+
+There was <number of reports, 'NO' when none> report of an incident.
+<!-- Provide details -->
+
+### Summary of Police Matters
+
+There were <number of reports, 'NO' when none> police matters.
+<!-- Provide details where necessary -->
+
+### Policy changes
+
+There were <number of reports, 'NO' when none> policy changes.  
+<!-- Provide details -->
+ 
+### Committee changes
+
+- <number of reports, 'NO' when none> members stepped down from (or joined) the committee.
+<!-- Provide details -->
+
+### Further relevant information
+
+<!-- Provide details of noteworthy news or update that should be captured -->
+
+```


### PR DESCRIPTION
Summary: Konrad and I had a meeting to add notes to the transparency report to fill the backlog.

With this PR, I am adding details as needed.
